### PR TITLE
Fix Python for sqlite

### DIFF
--- a/flowforge-docker/Dockerfile
+++ b/flowforge-docker/Dockerfile
@@ -3,7 +3,8 @@ FROM node:16-alpine
 ARG REGISTRY
 RUN if [[ ! -z "$REGISTRY" ]] ; then npm config set @flowforge:registry "$REGISTRY"; fi
 
-RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python2
+RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
+RUN ln -s `which python3` /usr/bin/python
 
 WORKDIR /usr/src/forge
 RUN mkdir app bin etc var


### PR DESCRIPTION
Stops trying to install Python2 and symlinks /usr/bin/python3 to /usr/bin/python which is needed to build sqlite3 from source (on ARM64 since it downloads pre-built binaries for AMD64)

closes #19 

(We should look at moving up to sqlite3 5.0.8 or floating at latest at some point)