### PR TITLE
NPM Registry cache for offline installs.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,5 +84,19 @@ services:
     depends_on:
       - "forge"
 
+  # npm:
+  #   image: "verdaccio/verdaccio:5"
+  #   networks:
+  #     - flowforge
+  #   restart: always
+  #   environment:
+  #     - "VIRTUAL_HOST=npm.example.com"
+  #     - "VIRTUAL_PORT=4873"
+  #   volumes:
+  #     - "./npm/conf:/verdaccio/conf"
+  #     - "./npm/storage:/verdaccio/storage"
+  #   depends_on:
+  #     - nginx
+
 networks:
   flowforge:

--- a/etc/flowforge.yml
+++ b/etc/flowforge.yml
@@ -54,7 +54,7 @@ driver:
 
     ## Kubectl conf file to contact the cluster
     # config_file: /opt/share/projects/flowforge/test/config
-    # regsitry: hub.flowforge.com
+    # registry: hub.flowforge.com
 
 #################################################
 # Email Configuration                           #

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,82 @@
+# FlowFuse offline NPM repository
+
+The following instructions are for using FlowFuse and the FlowFuse Device Agent
+on a network with no access to the Internet. It provides a way to install 
+Node-RED and Node-RED nodes into both "cloud" Instances and Device Instances.
+
+It works by providing a cache of the required NPM modules in a private NPM
+repository. You will need to populate this repository from a machine that has 
+access to the Internet.
+
+## Creating cache
+
+These tasks must be done one a machine with access to the Internet and has
+docker installed.
+
+1. Copy the content of the `npm/online` directory to the Internet connected machine
+2. If needed edit the `npm/online/temp/package.json` or the `npm/online/populate.sh` 
+script to add any extra nodes that need to be cached.
+3. From the `npm/online` directory run the `./populate.sh` script
+4. Copy the `npm-cache.tgz` to the offline machine into the `npm` directory
+5. run `sudo tar -zxf npm-cache.tgz` to unpack the cache into the `npm/storage` directory
+
+This step should be repeated any time new nodes are required or before any upgrades or 
+deploying new versions of the Device Agent.
+
+## Enabling on the offline machine
+
+Edit the `docker-compose.yml` and uncomment the following lines:
+
+```
+  npm:
+    image: "verdaccio/verdaccio:5"
+    networks:
+      - flowforge
+    restart: always
+    environment:
+      - "VIRTUAL_HOST=npm.example.com"
+      - "VIRTUAL_PORT=4873"
+    volumes:
+      - "./npm/conf:/verdaccio/conf"
+      - "./npm/storage:/verdaccio/storage"
+    depends_on:
+      - nginx
+```
+
+You should also update the value of the `VIRTUAL_HOST` entry appropriately to 
+use the domain already configured with a wild card domain in your local DNS.
+
+Once complete you can start the npm registry container by running:
+
+```
+docker compose up -d
+```
+
+## Configuring FlowFuse
+
+As an FlowFuse Administrator open the "Admin Settings" page and navigate to
+the Templates section.
+
+Under each Template's Palette section add the following line to the 
+`NPM configuration file`
+
+```
+registry=http://npm.example.com
+```
+
+Changing the hostname to match the one provided in the `VIRTUAL_HOST` entry
+set when changing the `docker-compose.yml` file.
+
+Be aware that this will only apply to any newly created Instances, you will
+have to manually edit the settings of any existing Instances.
+
+## Installing the Device Agent
+
+When installing the device agent on a machine in the offline network the 
+registry hostname should be passed to npm
+
+```
+npm install --registry=http://npm.example.com -g @flowfuse/device-agent
+```
+
+Again changing `npm.example.com` for the correct host name.

--- a/npm/conf/config.yaml
+++ b/npm/conf/config.yaml
@@ -1,0 +1,10 @@
+storage: /verdaccio/storage
+web:
+  enabled: false
+packages:
+  '@*/*':
+    access: $all
+  '**':
+    access: $all
+log:
+  - {type: stdout, format: pretty, level: http}

--- a/npm/online/conf/config.yaml
+++ b/npm/online/conf/config.yaml
@@ -1,0 +1,14 @@
+storage: /verdaccio/storage
+web:
+  enabled: false
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org
+packages:
+  '@*/*':
+    access: $all
+  '**':
+    access: $all
+    proxy: npmjs
+log:
+  - {type: stdout, format: pretty, level: http}

--- a/npm/online/populate.sh
+++ b/npm/online/populate.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+docker run --rm -d -v `pwd`/conf:/verdaccio/conf -v `pwd`/storage:/verdaccio/storage -p 4873:4873 --name npm-cache verdaccio/verdaccio:5
+
+sleep 15
+
+cd temp
+rm package-lock.json
+npm --registry=http://localhost:4873 install
+npm --registry=http://localhost:4873 install node-red@latest
+npm --registry=http://localhost:4873 install node-red@3.1.5
+npm --registry=http://localhost:4873 install node-red@3.0.2
+
+rm -rf node_modules
+
+cd ..
+
+docker stop npm-cache
+
+tar -zcf npm-cache.tgz storage

--- a/npm/online/temp/package.json
+++ b/npm/online/temp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "populate-cache",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A list of nodes to populate offline cache",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "FlowForge Inc.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@flowfuse/device-agent": "^2.2.0",
+    "@flowfuse/driver-docker": "^2.0.0",
+    "@flowfuse/flowfuse": "^2.0.1",
+    "@flowfuse/node-red-dashboard": "latest",
+    "@flowforge/nr-tools-plugin": "latest",
+    "nrlint": "latest",
+    "node-red-debugger": "latest",
+    "node-red-node-email": "latest",
+    "node-red-node-mysql": "latest",
+    "node-red-node-base64": "latest",
+    "node-red-contrib-postgresql": "latest",
+    "node-red-contrib-buffer-parser": "latest",
+    "node-red-contrib-influxdb": "latest",
+    "node-red-contrib-omron-fins": "latest",
+    "node-red-contrib-mcprotocol": "latest"
+  }
+}


### PR DESCRIPTION
part of FlowFuse/flowfuse#3461

## Description

<!-- Describe your changes in detail -->
Adds support to build an offline npm registry for running on air gapped networks

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/3461

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

