### PR TITLE
Fix access to scoped packages

### DIFF
--- a/npm/online/conf/config.yaml
+++ b/npm/online/conf/config.yaml
@@ -7,6 +7,7 @@ uplinks:
 packages:
   '@*/*':
     access: $all
+    proxy: npmjs
   '**':
     access: $all
     proxy: npmjs


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
The online version of the npm registry didn't allow access to all scoped packages.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

