### PR TITLE
Support npm offline for windows

### DIFF
--- a/npm/online/.gitignore
+++ b/npm/online/.gitignore
@@ -1,0 +1,5 @@
+temp/node_modules
+temp/cache
+temp/package-lock.json
+npm-cache.tgz
+storage/*

--- a/npm/online/conf/config.yaml
+++ b/npm/online/conf/config.yaml
@@ -7,6 +7,7 @@ uplinks:
 packages:
   '@*/*':
     access: $all
+    proxy: npmjs
   '**':
     access: $all
     proxy: npmjs

--- a/npm/online/populate.bat
+++ b/npm/online/populate.bat
@@ -1,0 +1,27 @@
+@echo off
+
+docker run --rm -d -v "%cd%\conf":/verdaccio/conf -v "%cd%\storage":/verdaccio/storage -p 4873:4873 --name npm-cache verdaccio/verdaccio:5
+
+timeout /T 5 /NOBREAK
+
+cd temp
+rmdir /S /Q node_modules
+rmdir /S /Q cache
+md cache
+SET npm_config_cache=cache
+del package-lock.json
+pause
+call npm --registry=http://localhost:4873 install
+call npm --registry=http://localhost:4873 install node-red@latest
+call npm --registry=http://localhost:4873 install node-red@3.1.5
+call npm --registry=http://localhost:4873 install node-red@3.0.2
+
+rmdir /S /Q node_modules
+rmdir /S /Q cache
+del package-lock.json
+
+cd ..
+
+docker stop npm-cache
+
+tar -zcf npm-cache.tgz storage

--- a/npm/online/populate.sh
+++ b/npm/online/populate.sh
@@ -2,16 +2,22 @@
 
 docker run --rm -d -v `pwd`/conf:/verdaccio/conf -v `pwd`/storage:/verdaccio/storage -p 4873:4873 --name npm-cache verdaccio/verdaccio:5
 
-sleep 15
+sleep 5
 
 cd temp
 rm package-lock.json
+rm -rf node_modules
+rm -rf cache
+mkdir cache
+export npm_config_cache=cache
 npm --registry=http://localhost:4873 install
 npm --registry=http://localhost:4873 install node-red@latest
 npm --registry=http://localhost:4873 install node-red@3.1.5
 npm --registry=http://localhost:4873 install node-red@3.0.2
 
 rm -rf node_modules
+rm -rf cache
+rm package-lock.json
 
 cd ..
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Make the offline npm cache populate script work on windows

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

