### PR TITLE
Ensure ssl-certs dir exists

### DIFF
--- a/node-red-container/Dockerfile
+++ b/node-red-container/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /data
 RUN npm install
 
 USER root
+RUN mkdir -p /usr/local/ssl-certs
 
 WORKDIR /usr/src/flowforge-nr-launcher
 RUN chown node-red:node-red /data/* /usr/src/flowforge-nr-launcher


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
When using the `privateCA` option the cert file is mounted on `/usr/local/ssl-certs/chain.pem` but the `ssl-certs` dir does not exist in the container. This is not a problem on k8s as the directory will be created, but this fails on docker.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

