### PR TITLE
Lock nginx-proxy to a fixed tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     # environment:
       # - "HTTPS_METHOD=redirect"
   # acme:
-  #   image: nginxproxy/acme-companion
+  #   image: nginxproxy/acme-companion:2.4.0
   #   restart: always
   #   volumes:
   #     - "/var/run/docker.sock:/var/run/docker.sock:ro"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   nginx:
-    image: nginxproxy/nginx-proxy
+    image: nginxproxy/nginx-proxy:1.6.0
     networks:
       - flowforge 
     restart: always


### PR DESCRIPTION
The `latest` tag tracks git head which may be more likely to be broken

## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

