### PR TITLE
fix: Remove interpolation when creating TLS certificates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,9 +77,9 @@ configs:
     content: |
       client_max_body_size 5m;
   nginx_tls_crt:
-    environment: ${TLS_ENABLED:+TLS_CERTIFICATE}
+    environment: TLS_CERTIFICATE
   nginx_tls_key:
-    environment: ${TLS_ENABLED:+TLS_KEY}
+    environment: TLS_KEY
   postgres_db_setup:
     content: |
       #!/bin/sh


### PR DESCRIPTION
## Description

This pull request removes an interpolation while creating a content of TLS certificate and key files.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

