### PR TITLE
Ensure the broker service name doesn't change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ configs:
         options:
           socket: /tmp/docker.sock
       broker:
-        url: mqtt://teamBroker:1883
+        url: mqtt://broker:1883
         public_url: ws${TLS_ENABLED:+s}://mqtt.${DOMAIN:?error}
         teamBroker:
           enabled: true
@@ -71,7 +71,7 @@ configs:
       #    ssl_protocols TLSv1.2;
       #    ssl_certificate /etc/nginx/certs/${DOMAIN}.crt;
       #    ssl_certificate_key /etc/nginx/certs/${DOMAIN}.key;
-      #    proxy_pass teamBroker:1883;
+      #    proxy_pass broker:1883;
       #  }
       #}
   postgres_db_setup:
@@ -436,7 +436,7 @@ services:
         target: /docker-entrypoint-initdb.d/02-setup-context-db.sh
     volumes:
       - db:/var/lib/postgresql/data
-  teamBroker:
+  broker:
     image: emqx/emqx:5.8.0
     networks:
       - flowforge
@@ -476,7 +476,7 @@ services:
     depends_on:
       - "postgres"
       - "nginx"
-      - "teamBroker"
+      - "broker"
 
   file-server:
     image: "flowfuse/file-server:2.10.0"


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Revert the change of service name so exising Node-RED instances can reconnect to the New EQMX broker after an upgrade.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

