### PR TITLE
Bump max MQTT packet to 128mb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,6 +186,9 @@ configs:
           }
         ]
       }
+      mqtt {
+        max_packet_size: 128MB
+      }
       listeners {
         ssl {
           default {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Ensure the default 1mb packet size is overrident

## Related Issue(s)

<!-- What issue does this PR relate to? -->
Tuning FFC
## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

