### PR TITLE
ci: Do not run test against `release-*` branches

### DIFF
--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - '!release-**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - '!release-**'
 
 jobs:
   default-stack:


### PR DESCRIPTION
## Description

This pull requests ensures that `Test Docker Compose` workflow will not be launched agains branches matching pattern `release-*`.
This will stop tests execution during the release process.

## Related Issue(s)

Closes https://github.com/FlowFuse/docker-compose/issues/171

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

