### PR TITLE
Fix indentation on team broker TLS section.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,14 +71,14 @@ configs:
   nginx_stream:
     content: |
       # stream {
-      #  server {
-      #    listen 1884 ssl;
-      #    ssl_protocols TLSv1.2;
-      #    ssl_certificate /etc/nginx/certs/${DOMAIN}.crt;
-      #    ssl_certificate_key /etc/nginx/certs/${DOMAIN}.key;
-      #    proxy_pass broker:1883;
-      #  }
-      #}
+      #   server {
+      #     listen 1884 ssl;
+      #     ssl_protocols TLSv1.2;
+      #     ssl_certificate /etc/nginx/certs/${DOMAIN}.crt;
+      #     ssl_certificate_key /etc/nginx/certs/${DOMAIN}.key;
+      #     proxy_pass broker:1883;
+      #   }
+      # }
   postgres_db_setup:
     content: |
       #!/bin/sh


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Fix the indentation for the commented out block so it's consistent.

The hash and a single space after should be removed to enable this section.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

