### PR TITLE
ci: Add Docker Compose files as assets to a release

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,3 +1,4 @@
+name: Build and push containers
 on: 
   push: 
     tags:
@@ -61,3 +62,20 @@ jobs:
           git checkout maintenance
           git reset --hard origin/main
           git push --force origin maintenance
+
+  release-compose-files:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'flowforge/docker-compose'
+
+      - name: Add assets to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            docker-compose.yml
+            docker-compose-quick-start.yml


### PR DESCRIPTION
## Description

This pull request adds the `release-compose-files` job to the `Build and push containers` workflow. The job is responsible for adding `docker-compose.yml` and `docker-compose-quick-start.yml` files as assets to the coresponding release.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

