### PR TITLE
Add node-red editor cache files

### DIFF
--- a/flowforge-docker/Dockerfile
+++ b/flowforge-docker/Dockerfile
@@ -9,6 +9,10 @@ RUN apk add --no-cache --virtual build-base g++ make py3-pip sqlite-dev python3
 
 WORKDIR /usr/src/forge
 RUN mkdir app bin etc var
+WORKDIR /usr/src/forge/var
+COPY install-device-cache.sh .
+RUN ./install-device-cache.sh && rm install-device-cache.sh
+WORKDIR /usr/src/forge
 COPY package.json /usr/src/forge/app
 WORKDIR /usr/src/forge/app
 RUN npm install --production --no-audit --no-fund 

--- a/flowforge-docker/install-device-cache.sh
+++ b/flowforge-docker/install-device-cache.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -x
+
+VERSION_LIST="4.0.0 4.0.1 4.0.2 4.0.3 4.0.4 4.0.5 4.0.7"
+
+mkdir -p device/cache
+cd device/cache
+
+pwd
+
+for V in $VERSION_LIST
+do  
+  echo $V
+  mkdir $V
+  ls -l
+  npm install --omit=dev --omit=optional --no-audit --no-fund --prefix "$V" "@node-red/editor-client@$V"
+done
+
+pwd
+ls -l
+du -sh


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Adds @node-red/editor-client cache files for Device Editor access

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#3414

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

