### PR TITLE
ci: Wait for containers to build before testing docker compose

### DIFF
--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -4,19 +4,55 @@ on:
   push:
     branches:
       - main
-      - '!release-**'
+      - '!release-*'
   pull_request:
     branches:
       - main
-      - '!release-**'
+
 
 jobs:
   default-stack:
     name: Test default stack
     runs-on: ubuntu-latest
+    if: | 
+      !startsWith(github.head_ref, 'release-')
     steps:
-      - name: Checkout repository
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_APP_KEY }}
+
+      - name: Wait for container images build
+        run: |
+          while :; do
+            result=$(gh api repos/:owner/:repo/actions/workflows | jq -r '.workflows[] | select(.name=="Build and push containers") | .id' | xargs -I {} gh api repos/:owner/:repo/actions/workflows/{}/runs --jq '.workflow_runs | max_by(.run_number)')
+            status=$(echo "$result" | jq -r '.status')
+            conclusion=$(echo "$result" | jq -r '.conclusion')
+            if [[ "$status" == "completed" ]]; then
+              if [[ "$conclusion" == "success" ]]; then
+                echo "Build and push containers workflow completed successfully"
+                break
+              else
+                echo "Build and push containers workflow failed"
+                exit 1
+              fi
+            elif [[ "$status" == "in_progress" ]]; then
+              echo "Build and push containers workflow is still running"
+              sleep 60
+            else
+              echo "Build and push containers workflow returned unexpected status: $status"
+              exit 1
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create .env file for default settings
         run: |
@@ -91,9 +127,45 @@ jobs:
   quick-start-stack:
     name: Test quick-start stack
     runs-on: ubuntu-latest
+    if: | 
+      !startsWith(github.head_ref, 'release-')
     steps:
-      - name: Checkout repository
+      - name: Generate a token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_APP_KEY }}
+
+      - name: Wait for container images build
+        run: |
+          while :; do
+            result=$(gh api repos/:owner/:repo/actions/workflows | jq -r '.workflows[] | select(.name=="Build and push containers") | .id' | xargs -I {} gh api repos/:owner/:repo/actions/workflows/{}/runs --jq '.workflow_runs | max_by(.run_number)')
+            status=$(echo "$result" | jq -r '.status')
+            conclusion=$(echo "$result" | jq -r '.conclusion')
+            if [[ "$status" == "completed" ]]; then
+              if [[ "$conclusion" == "success" ]]; then
+                echo "Build and push containers workflow completed successfully"
+                break
+              else
+                echo "Build and push containers workflow failed"
+                exit 1
+              fi
+            elif [[ "$status" == "in_progress" ]]; then
+              echo "Build and push containers workflow is still running"
+              sleep 60
+            else
+              echo "Build and push containers workflow returned unexpected status: $status"
+              exit 1
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create .env file for default settings
         run: |

--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -11,8 +11,8 @@ on:
 
 
 jobs:
-  default-stack:
-    name: Test default stack
+  wait-for-containers-build:
+    name: Wait for container images build
     runs-on: ubuntu-latest
     if: | 
       !startsWith(github.head_ref, 'release-')
@@ -23,6 +23,11 @@ jobs:
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Wait for container images build
         run: |
@@ -49,10 +54,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  default-stack:
+    name: Test default stack
+    needs: wait-for-containers-build
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create .env file for default settings
         run: |
@@ -126,46 +134,11 @@ jobs:
 
   quick-start-stack:
     name: Test quick-start stack
+    needs: wait-for-containers-build
     runs-on: ubuntu-latest
-    if: | 
-      !startsWith(github.head_ref, 'release-')
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.GH_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_BOT_APP_KEY }}
-
-      - name: Wait for container images build
-        run: |
-          while :; do
-            result=$(gh api repos/:owner/:repo/actions/workflows | jq -r '.workflows[] | select(.name=="Build and push containers") | .id' | xargs -I {} gh api repos/:owner/:repo/actions/workflows/{}/runs --jq '.workflow_runs | max_by(.run_number)')
-            status=$(echo "$result" | jq -r '.status')
-            conclusion=$(echo "$result" | jq -r '.conclusion')
-            if [[ "$status" == "completed" ]]; then
-              if [[ "$conclusion" == "success" ]]; then
-                echo "Build and push containers workflow completed successfully"
-                break
-              else
-                echo "Build and push containers workflow failed"
-                exit 1
-              fi
-            elif [[ "$status" == "in_progress" ]]; then
-              echo "Build and push containers workflow is still running"
-              sleep 60
-            else
-              echo "Build and push containers workflow returned unexpected status: $status"
-              exit 1
-            fi
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create .env file for default settings
         run: |


### PR DESCRIPTION
## Description

This pull request assures, that `Test Docker Compose` pipeline:
* will not run against `release-*` branch
* will wait for completion of `Build and push containers` workflow  before proceeding 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

