### PR TITLE
fix: Clariby `DB_*` entries in `.env.example` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ APP_TLS_CERTIFICATE=""
 APP_TLS_KEY=""
 
 ### Database configuration
+### Fill only if you want to use an external database (https://flowfuse.com/docs/install/docker/#how-to-use-external-database-server%3F), leave empty otherwise
 DB_HOST=""
 DB_USER=""
 DB_PASSWORD=""


### PR DESCRIPTION
## Description

This PR adds a comment in `.env.example` file informing when `DB_*` variables should be filled.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

