### PR TITLE
ci: Remove `Resync Maintenance` step from the pipeline

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -55,13 +55,6 @@ jobs:
           username: flowfuse
           password: ${{ secrets.DOCKER_HUB_PASSWORD_FLOWFUSE }}
           readme-filepath: docker-compose/README.md
-      - name: Resync Maintenance
-        if: ${{ endsWith(github.ref, '.0') }}
-        run: |
-          cd docker-compose
-          git checkout maintenance
-          git reset --hard origin/main
-          git push --force origin maintenance
 
   release-compose-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This pull request removes `Resync Maintenance` step from the `Build and push containers` workflow.

## Related Issue(s)

Closes https://github.com/FlowFuse/helm/issues/486

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

