### PR TITLE
feat: Enable storage for Node-RED intances

### DIFF
--- a/docker-compose-quick-start.yml
+++ b/docker-compose-quick-start.yml
@@ -19,6 +19,8 @@ configs:
         type: docker
         options:
           socket: /tmp/docker.sock
+          storage:
+            enabled: true
       broker:
         url: mqtt://broker:1883
         public_url: ws://mqtt.${DOMAIN:?error}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ configs:
         options:
           socket: /tmp/docker.sock
           ${DOCKER_DRIVER_PRIVATE_CA_PATH:+privateCA: ${DOCKER_DRIVER_PRIVATE_CA_PATH}}
+          storage:
+            enabled: true
       broker:
         url: mqtt://broker:1883
         public_url: ws${TLS_ENABLED:+s}://mqtt.${DOMAIN:?error}


### PR DESCRIPTION
## Description

This pull request ensures, that configuration option responsible for using persistent storage by Node-RED instances is enabled by default on both docker compose yaml files.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

