### PR TITLE
fix: Set proper permissions for initialization scripts

### DIFF
--- a/docker-compose-quick-start.yml
+++ b/docker-compose-quick-start.yml
@@ -116,8 +116,10 @@ services:
     configs:
       - source: postgres_db_setup
         target: /docker-entrypoint-initdb.d/01-setup-db.sh
+        mode: 0664
       - source: postgres_context_setup
         target: /docker-entrypoint-initdb.d/02-setup-context-db.sh
+        mode: 0664
     volumes:
       - db:/var/lib/postgresql/data
     healthcheck:
@@ -141,6 +143,7 @@ services:
     configs:
       - source: flowfuse_broker
         target: /etc/mosquitto/mosquitto.conf
+        mode: 0664
     
   forge:
     image: "flowfuse/forge-docker"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -484,8 +484,10 @@ services:
     configs:
       - source: emqx
         target: /opt/emqx/data/configs/cluster.hocon
+        mode: 0664
       - source: emqx-api
         target: /mounted/config/api-keys
+        mode: 0664
     volumes:
       - emqx:/opt/emqx/data
 


### PR DESCRIPTION
## Description

This pull requests sets proper permissions for initialization scripts mounted in the postgres container.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

