### PR TITLE
Add restart: always policy to broker service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -469,6 +469,7 @@ services:
     image: emqx/emqx:5.8.0
     networks:
       - flowforge
+    restart: always
     ports:
       - 1883:1883
     healthcheck:


### PR DESCRIPTION
Adds `restart: always` policy to the broker service in the docker-compose.yml.
Ensures that the MQTT broker container automatically restarts after Docker daemon or host restarts, improving stability and uptime of the service in typical deployment environments.