### PR TITLE
ci: Handle the `queued` status when waiting for containers to build  in `Test Docker Compose` workflow

### DIFF
--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -43,7 +43,7 @@ jobs:
                 echo "Build and push containers workflow failed"
                 exit 1
               fi
-            elif [[ "$status" == "in_progress" ]]; then
+            elif [[ "$status" == "in_progress" || "$status" == "queued" ]]; then
               echo "Build and push containers workflow is still running"
               sleep 60
             else


### PR DESCRIPTION
## Description

This pull reuqest ensures, that  the `queue` status for `Build and push containers` pipeline is handled properly in the `Test Docker Compose` workflow.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

