### PR TITLE
ci: Wait before checking build workflow status in `Test Docker Compose`

### DIFF
--- a/.github/workflows/test-docker-compose.yaml
+++ b/.github/workflows/test-docker-compose.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Wait for container images build
         run: |
+          sleep 15 # Wait for the build workflow to be registered
           while :; do
             result=$(gh api repos/:owner/:repo/actions/workflows | jq -r '.workflows[] | select(.name=="Build and push containers") | .id' | xargs -I {} gh api repos/:owner/:repo/actions/workflows/{}/runs --jq '.workflow_runs | max_by(.run_number)')
             status=$(echo "$result" | jq -r '.status')


### PR DESCRIPTION
## Description

This pull request waits 15 seconds before checking the status of `Build and push containers` workflow within `Test Docker Compose` one.
During the release it might happen, that build workflow is not yet registered by the GitHub API and test workflow is unable to check it's status. In result, test pipeline will fail since there is no new container image version available.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

