### PR TITLE
Minimise Device Editor cache

### DIFF
--- a/flowforge-docker/install-device-cache.sh
+++ b/flowforge-docker/install-device-cache.sh
@@ -13,6 +13,13 @@ do
   mkdir $V
   ls -l
   npm install --omit=dev --omit=optional --no-audit --no-fund --prefix "$V" "@node-red/editor-client@$V"
+  # clean up what is not needed
+  rm -rf "$V/node_modules/@node-red/editor-client/public/vendor/font-awesome"
+  rm -rf "$V/node_modules/@node-red/editor-client/public/vendor/jquery"
+  rm -rf "$V/node_modules/@node-red/editor-client/public/vendor/ace"
+  rm -rf "$V/node_modules/@node-red/editor-client/public/vendor/monaco/dist/locale"
+  rm -rf "$V/node_modules/@node-red/editor-client/public/vendor/monaco/dist/theme"
+  rm -rf "$V/node_modules/@node-red/editor-client/locales"
 done
 
 pwd


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Delete all the bits of @node-red/editor-client we don't actually use for the device editor cache to make the containers smaller

https://github.com/FlowFuse/flowfuse/blob/512ec7a71cb8e54054133560f318e4d15657091d/forge/ee/lib/deviceEditor/DeviceTunnelManager.js#L37-L45