### PR TITLE
Fix $ escaping and add LETSENCRYPT for npm registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -422,7 +422,7 @@ configs:
           adminSecret: ${NPM_PASSWORD:-secret}
       packages:
         '@*/*':
-          access: $authenticated
+          access: $$authenticated
       log: { type: stdout, format: pretty, level: http }
 
 services:
@@ -581,6 +581,7 @@ services:
     environment:
       - "VIRTUAL_HOST=npm.${DOMAIN:?error}"
       - "VIRTUAL_PORT=4873"
+      - "LETSENCRYPT_HOST=npm.${DOMAIN}"
     configs:
       - source: npm-registry-config
         target: /verdaccio/conf/config.yaml


### PR DESCRIPTION
fixes #295

## Description

<!-- Describe your changes in detail -->
- Add the missing env var to the npm-registry service
- double up the $ in the npm-registry config to prevent it being subsituted

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#295 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

