### PR TITLE
feat: Mount DOCKER_DRIVER_PRIVATE_CA_PATH in forge service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -520,12 +520,14 @@ services:
     environment:
       - "VIRTUAL_HOST=${APPLICATION_DOMAIN:-forge.${DOMAIN}}"
       - "LETSENCRYPT_HOST=${APPLICATION_DOMAIN:-forge.${DOMAIN}}"
+#      - "NODE_EXTRA_CA_CERTS=/usr/local/ssl-certs/chain.pem"
     configs:
       - source: flowfuse
         target: /usr/src/forge/etc/flowforge.yml
     volumes:
       - "/var/run/docker.sock:/tmp/docker.sock"
       - flowfuse-persistent-storage:/opt/persistent-storage
+#      - ${DOCKER_DRIVER_PRIVATE_CA_PATH}:/usr/local/ssl-certs/chain.pem
     depends_on:
       - "postgres"
       - "nginx"


### PR DESCRIPTION
## Description

This pull request adds configuration to the `docker-compose.yml` file that, once uncommented, allows mounting a file defined via DOCKER_DRIVER_PRIVATE_CA_PATH environment variable inside the `forge` service.

This solution is ugly, and I don't like it, but with YAML limitations, I couldn't find a cleaner way for this.

## Related Issue(s)

Closes https://github.com/FlowFuse/docker-compose/issues/284

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

