### PR TITLE
Remove armv7 as no NodeJS 24 alpine container

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           context: docker-compose/flowforge-docker
           file: docker-compose/flowforge-docker/Dockerfile
-          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
       - name: Push README


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Remove building arm/v7 containers after move to NodeJS 24.