### PR TITLE
fix: Add `assistant` and `expert` to the `flowfuse` config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,12 @@ DOCKER_DRIVER_PRIVATE_CA_PATH=""
 
 ### NPM Registry options
 NPM_PASSWORD=""
+
+### Assistant options
+ASSISTANT_URL="https://expert.flowfuse.com/v1/openai"
+ASSISTANT_TOKEN="FlowFuseAssistantTokenEnv"
+
+### Expert options
+EXPERT_URL="https://expert.flowfuse.com/v4/expert"
+EXPERT_TOKEN="FlowFuseExpertTokenEnv"
+EXPERT_BROKER_SERVER="expert-broker.flowfuse.com"

--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,9 @@ NPM_PASSWORD=""
 
 ### Assistant options
 ASSISTANT_URL="https://expert.flowfuse.com/v1/openai"
-ASSISTANT_TOKEN="FlowFuseAssistantTokenEnv"
+ASSISTANT_TOKEN="<Assistant Token>"
 
 ### Expert options
 EXPERT_URL="https://expert.flowfuse.com/v4/expert"
-EXPERT_TOKEN="FlowFuseExpertTokenEnv"
+EXPERT_TOKEN="<Expert Token>"
 EXPERT_BROKER_SERVER="expert-broker.flowfuse.com"

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ NPM_PASSWORD=""
 
 ### Assistant options
 ASSISTANT_URL="https://expert.flowfuse.com/v1/openai"
-ASSISTANT_TOKEN="<Assistant Token>"
+ASSISTANT_TOKEN=""
 
 ### Expert options
 EXPERT_URL="https://expert.flowfuse.com/v4/expert"

--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,5 @@ ASSISTANT_TOKEN="<Assistant Token>"
 
 ### Expert options
 EXPERT_URL="https://expert.flowfuse.com/v4/expert"
-EXPERT_TOKEN="<Expert Token>"
+EXPERT_TOKEN=""
 EXPERT_BROKER_SERVER="expert-broker.flowfuse.com"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,21 @@ configs:
           password: ${NPM_PASSWORD:-secret}
       ai:
         enabled: true
+      assistant:
+        enabled: true
+        service:
+          url: ${ASSISTANT_URL:-https://expert.flowfuse.com/v1/openai}
+          token: ${ASSISTANT_TOKEN:-FlowFuseAssistantToken}
+      expert:
+        enabled: true
+        service:
+          url: ${EXPERT_URL:-https://expert.flowfuse.com/v4/expert}
+          token: ${EXPERT_TOKEN:-FlowFuseExpertToken}
+        centralBroker:
+          server: ${EXPERT_BROKER_SERVER:-expert-broker.flowfuse.com}:${EXPERT_BROKER_PORT:-8883}
+          ssl: true
+        insights:
+          enabled: true
   flowfuse_storage:
     content: |
       port: 3001


### PR DESCRIPTION
## Description

This pull request adds the `assistant` and `expert` configurations to the `flowfuse` config + adds a possibility to cusotmize URLs and tokens using environmental variables.

## Related Issue(s)

https://github.com/FlowFuse/docker-compose/issues/351

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

