### PR TITLE
Add team broker admin API credentials for the Expert bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,8 @@ ASSISTANT_TOKEN=""
 EXPERT_URL="https://expert.flowfuse.com/v4/expert"
 EXPERT_TOKEN=""
 EXPERT_BROKER_SERVER="expert-broker.flowfuse.com"
+
+### Team broker admin API credentials (used to bootstrap the local EMQX and to
+### provision the Expert chat bridge). Both sides read the same values.
+BROKER_API_KEY="flowfuse"
+BROKER_API_SECRET="verySecret"

--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,5 @@ EXPERT_BROKER_SERVER="expert-broker.flowfuse.com"
 
 ### Team broker admin API credentials (used to bootstrap the local EMQX and to
 ### provision the Expert chat bridge). Both sides read the same values.
-BROKER_API_KEY="flowfuse"
-BROKER_API_SECRET="verySecret"
+BROKER_API_KEY=""
+BROKER_API_SECRET=""

--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,6 @@ EXPERT_BROKER_SERVER="expert-broker.flowfuse.com"
 
 ### Team broker admin API credentials (used to bootstrap the local EMQX and to
 ### provision the Expert chat bridge). Both sides read the same values.
+### Leave empty to use defaults
 BROKER_API_KEY=""
 BROKER_API_SECRET=""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,12 @@ configs:
         public_url: ws${TLS_ENABLED:+s}://mqtt.${DOMAIN:?error}
         teamBroker:
           enabled: true
+          # Admin API credentials for the local EMQX (bootstrapped in the emqx-api
+          # config below). Required for the Expert chat bridge to provision itself.
+          api:
+            url: http://broker:18083/api/v5
+            key: ${BROKER_API_KEY:-flowfuse}
+            secret: ${BROKER_API_SECRET:-verySecret}
       fileStore:
         enable: true
         url: http://file-server:3001
@@ -426,7 +432,7 @@ configs:
       }
   emqx-api:
     content: |
-      flowfuse:verySecret:administrator
+      ${BROKER_API_KEY:-flowfuse}:${BROKER_API_SECRET:-verySecret}:administrator
   npm-registry-config:
     content: |
       storage: /verdaccio/storage


### PR DESCRIPTION
## Description

The template enables Expert (`expert.enabled: true` with `centralBroker.server`) and the team broker (`broker.teamBroker.enabled: true`), but the team broker had no `api` block. The Expert chat bridge provisions itself by calling the EMQX admin API, so without those credentials the bridge fails to build — forge logs `Error syncing EMQX bridge: Invalid URL` and no connector is created, leaving chat with no responses.

This adds `broker.teamBroker.api` (url + key + secret) and drives both it and the existing `emqx-api` bootstrap key from the same `BROKER_API_KEY` / `BROKER_API_SECRET` variables, so an override can't put the two out of sync. Defaults match the previously hardcoded bootstrap (`flowfuse` / `verySecret`), so behaviour is unchanged for anyone not overriding them.

## Verification

Reproduced on a local stack: with the `api` block removed the bridge logs `Invalid URL` and creates 0 connectors; with it present the connector comes up `status=connected` and all bridge rules/sources are created. Confirmed `docker compose config` renders correctly with defaults and with overrides (both sides stay in sync).